### PR TITLE
Add back metrics-parser for monitoring

### DIFF
--- a/demo-oai.sh
+++ b/demo-oai.sh
@@ -1334,11 +1334,12 @@ start-gnb() {
             GNB_PATH="/opt/oai-gnb"
         fi
 
-        kubectl -n $NS exec -it $POD_NAME -- /bin/bash -c "
-            ln -sf ${GNB_PATH}/nrMAC_stats.log /shared-logs/nrMAC_stats.log;
-            ln -sf ${GNB_PATH}/nrL1_stats.log /shared-logs/nrL1_stats.log;
-            ln -sf ${GNB_PATH}/nrRRC_stats.log /shared-logs/nrRRC_stats.log;
-        "
+        kubectl -n $NS exec $POD_NAME -c gnb -- /bin/bash -c "
+        nohup /bin/bash -c 'while true; do 
+            \cp $GNB_PATH/nrL1_stats.log /shared-logs/nrL1_stats.log 2>/dev/null;
+            \cp $GNB_PATH/nrMAC_stats.log /shared-logs/nrMAC_stats.log 2>/dev/null;
+            \cp $GNB_PATH/nrRRC_stats.log /shared-logs/nrRRC_stats.log 2>/dev/null;
+        done' >/dev/null 2>&1 &"
         
         echo "Monitoring setup completed."
     fi

--- a/demo-oai.sh
+++ b/demo-oai.sh
@@ -1295,7 +1295,7 @@ setup_stats_monitor() {
     kubectl -n "$namespace" exec "$pod_name" -- /bin/bash -c "
     nohup /bin/bash -c 'while true; do 
         $copy_cmds
-        sleep 1;
+        sleep 0.1;
     done' >/dev/null 2>&1 &"
 }
 
@@ -1337,6 +1337,7 @@ start-gnb() {
 	    kubectl -n $NS wait pod --for=condition=Ready -l app.kubernetes.io/instance=oai-cu
 	    echo "helm install -n $NS oai-du ${RAN_DIR}"
 	    helm install -n $NS oai-du "${RAN_DIR}"
+        kubectl -n $NS wait pod --for=condition=Ready -l app.kubernetes.io/instance=oai-du
 	else
 	    # ${GNB_MODE} = 'cucpup'
 	    echo "helm -n $NS install oai-cu-cp oai-cu-cp/"
@@ -1351,6 +1352,7 @@ start-gnb() {
 	    kubectl -n $NS wait pod --for=condition=Ready -l app.kubernetes.io/instance=oai-cu-up
 	    echo "helm install -n $NS oai-du ${RAN_DIR}"
 	    helm install -n $NS oai-du "${RAN_DIR}"
+        kubectl -n $NS wait pod --for=condition=Ready -l app.kubernetes.io/instance=oai-du
 	fi
     fi
     if [[ "$MONITORING" == "true" ]]; then

--- a/demo-oai.sh
+++ b/demo-oai.sh
@@ -35,7 +35,7 @@ RUN_MODE="@DEF_RUN_MODE@" # in ['full', 'gnb-only', 'gnb-upf']
 GNB_MODE="@DEF_GNB_MODE@" # in ['monolithic', 'cudu', 'cucpup']
 export LOGS="@DEF_LOGS@" # boolean, true if logs are retrieved on pods
 export PCAP="@DEF_PCAP@" # boolean, true if pcap are generated on pods
-MONITORING="@DEF_MONITORING@" # boolean, true if prometheus metrics parser is generated on oai-gnb pod (monolithic)
+export MONITORING="@DEF_MONITORING@" # boolean, true if prometheus metrics parser is generated on oai-gnb pod (monolithic)
 export FLEXRIC="@DEF_FLEXRIC@" # boolean, true if flexRIC is included
 #
 export MCC="@DEF_MCC@"

--- a/demo-oai.sh
+++ b/demo-oai.sh
@@ -1321,6 +1321,31 @@ start-gnb() {
 	    helm install -n $NS oai-du "${RAN_DIR}"
 	fi
     fi
+    if [[ "$MONITORING" == "true" ]]; then
+        echo "Monitoring enabled. Configuring metrics inside pod..."
+
+        POD_NAME=$(kubectl -n $NS get pods -l app.kubernetes.io/instance=oai-gnb -o jsonpath="{.items[0].metadata.name}")
+
+        echo "Target pod: $POD_NAME"
+
+        if [[ "$RRU_TYPE" == "aw2s" ]]; then
+            GNB_PATH="/opt/oai-gnb-aw2s"
+        else
+            GNB_PATH="/opt/oai-gnb"
+        fi
+
+        kubectl -n $NS exec -it $POD_NAME -- /bin/bash -c "
+            mkdir -p /shared-logs;
+            touch /shared-logs/nrMAC_stats.log;
+            touch /shared-logs/nrL1_stats.log;
+            touch /shared-logs/nrRRC_stats.log;
+            ln -sf /shared-logs/nrMAC_stats.log ${GNB_PATH}/nrMAC_stats.log;
+            ln -sf /shared-logs/nrL1_stats.log ${GNB_PATH}/nrL1_stats.log;
+            ln -sf /shared-logs/nrRRC_stats.log ${GNB_PATH}/nrRRC_stats.log;
+        "
+        
+        echo "Monitoring setup completed."
+    fi
 }
 
 #################################################################################

--- a/demo-oai.sh
+++ b/demo-oai.sh
@@ -1268,6 +1268,38 @@ start-flexric() {
 #################################################################################
 
 
+# Helper function to start the background copy process inside a pod
+setup_stats_monitor() {
+    local pod_label=$1
+    local files=$2
+    local namespace=$3
+    local gnb_path=$4
+
+    # Get the pod name based on the instance label
+    local pod_name=$(kubectl -n "$namespace" get pods -l "app.kubernetes.io/instance=$pod_label" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
+    
+    if [[ -z "$pod_name" ]]; then
+        echo "Error: Could not find pod for $pod_label"
+        return 1
+    fi
+
+    echo "Configuring monitoring for $pod_name ($pod_label)..."
+
+    # Construct the copy command for the specified files
+    local copy_cmds=""
+    for f in $files; do
+        copy_cmds+="\cp $gnb_path/$f /shared-logs/$f 2>/dev/null; "
+    done
+
+    # Execute the background loop inside the pod
+    kubectl -n "$namespace" exec "$pod_name" -- /bin/bash -c "
+    nohup /bin/bash -c 'while true; do 
+        $copy_cmds
+        sleep 1;
+    done' >/dev/null 2>&1 &"
+}
+
+
 start-gnb() {
 
     if [[ $FLEXRIC = "true" ]]; then
@@ -1322,25 +1354,23 @@ start-gnb() {
 	fi
     fi
     if [[ "$MONITORING" == "true" ]]; then
-        echo "Monitoring enabled. Configuring metrics inside pod..."
+        echo "Monitoring enabled. Configuring log files copying logic..."
 
-        POD_NAME=$(kubectl -n $NS get pods -l app.kubernetes.io/instance=oai-gnb -o jsonpath="{.items[0].metadata.name}")
-
-        echo "Target pod: $POD_NAME"
-
-        if [[ "$RRU_TYPE" == "aw2s" ]]; then
-            GNB_PATH="/opt/oai-gnb-aw2s"
-        else
-            GNB_PATH="/opt/oai-gnb"
-        fi
-
-        kubectl -n $NS exec $POD_NAME -c gnb -- /bin/bash -c "
-        nohup /bin/bash -c 'while true; do 
-            \cp $GNB_PATH/nrL1_stats.log /shared-logs/nrL1_stats.log 2>/dev/null;
-            \cp $GNB_PATH/nrMAC_stats.log /shared-logs/nrMAC_stats.log 2>/dev/null;
-            \cp $GNB_PATH/nrRRC_stats.log /shared-logs/nrRRC_stats.log 2>/dev/null;
-        done' >/dev/null 2>&1 &"
+        GNB_PATH=$([[ "$RRU_TYPE" == "aw2s" ]] && echo "/opt/oai-gnb-aw2s" || echo "/opt/oai-gnb")
         
+        case ${GNB_MODE} in
+            "monolithic")
+                setup_stats_monitor "oai-gnb" "nrL1_stats.log nrMAC_stats.log nrRRC_stats.log" "$NS" "$GNB_PATH"
+                ;;
+            "cudu")
+                setup_stats_monitor "oai-du" "nrL1_stats.log nrMAC_stats.log" "$NS" "$GNB_PATH"
+                setup_stats_monitor "oai-cu" "nrRRC_stats.log" "$NS" "$GNB_PATH"
+                ;;
+            "cucpup")
+                setup_stats_monitor "oai-du" "nrL1_stats.log nrMAC_stats.log" "$NS" "$GNB_PATH"
+                setup_stats_monitor "oai-cu-cp" "nrRRC_stats.log" "$NS" "$GNB_PATH"
+                ;;
+        esac
         echo "Monitoring setup completed."
     fi
 }

--- a/demo-oai.sh
+++ b/demo-oai.sh
@@ -1339,9 +1339,9 @@ start-gnb() {
             touch /shared-logs/nrMAC_stats.log;
             touch /shared-logs/nrL1_stats.log;
             touch /shared-logs/nrRRC_stats.log;
-            ln -sf /shared-logs/nrMAC_stats.log ${GNB_PATH}/nrMAC_stats.log;
-            ln -sf /shared-logs/nrL1_stats.log ${GNB_PATH}/nrL1_stats.log;
-            ln -sf /shared-logs/nrRRC_stats.log ${GNB_PATH}/nrRRC_stats.log;
+            ln -s ${GNB_PATH}/nrMAC_stats.log /shared-logs/nrMAC_stats.log;
+            ln -s ${GNB_PATH}/nrL1_stats.log /shared-logs/nrL1_stats.log;
+            ln -s ${GNB_PATH}/nrRRC_stats.log /shared-logs/nrRRC_stats.log;
         "
         
         echo "Monitoring setup completed."

--- a/demo-oai.sh
+++ b/demo-oai.sh
@@ -1335,13 +1335,9 @@ start-gnb() {
         fi
 
         kubectl -n $NS exec -it $POD_NAME -- /bin/bash -c "
-            mkdir -p /shared-logs;
-            touch /shared-logs/nrMAC_stats.log;
-            touch /shared-logs/nrL1_stats.log;
-            touch /shared-logs/nrRRC_stats.log;
-            ln -s ${GNB_PATH}/nrMAC_stats.log /shared-logs/nrMAC_stats.log;
-            ln -s ${GNB_PATH}/nrL1_stats.log /shared-logs/nrL1_stats.log;
-            ln -s ${GNB_PATH}/nrRRC_stats.log /shared-logs/nrRRC_stats.log;
+            ln -sf ${GNB_PATH}/nrMAC_stats.log /shared-logs/nrMAC_stats.log;
+            ln -sf ${GNB_PATH}/nrL1_stats.log /shared-logs/nrL1_stats.log;
+            ln -sf ${GNB_PATH}/nrRRC_stats.log /shared-logs/nrRRC_stats.log;
         "
         
         echo "Monitoring setup completed."

--- a/demo_charts/values/oai-cu-cp.yq
+++ b/demo_charts/values/oai-cu-cp.yq
@@ -12,6 +12,7 @@
 
 .start.tcpdump               = (strenv(PCAP) == "true") |
 .includeTcpDumpContainer     = (strenv(LOGS) == "true") |
+.includeMetricsParser        = (strenv(MONITORING) == "true") |
 .persistent.sharedvolume     = (strenv(PCAP) == "true") |
 
 .resources.define            = (strenv(QOS_CUCP) == "true") |

--- a/demo_charts/values/oai-cu.yq
+++ b/demo_charts/values/oai-cu.yq
@@ -12,6 +12,7 @@
 
 .start.tcpdump               = (strenv(PCAP) == "true") |
 .includeTcpDumpContainer     = (strenv(LOGS) == "true") |
+.includeMetricsParser        = (strenv(MONITORING) == "true") |
 .persistent.sharedvolume     = (strenv(PCAP) == "true") |
 
 .resources.define            = (strenv(QOS_CU) == "true") |

--- a/demo_charts/values/oai-du-fhi-72.yq
+++ b/demo_charts/values/oai-du-fhi-72.yq
@@ -12,5 +12,7 @@
 .config.ruCPlaneMacAdd       = strenv(MAC_RU) |
 .config.ruUPlaneMacAdd       = strenv(MAC_RU) |
 
+.includeMetricsParser        = (strenv(MONITORING) == "true") |
+
 .resources.define            = (strenv(QOS_DU) == "true") |
 .nodeName                    = strenv(NODE_DU)

--- a/demo_charts/values/oai-du.yq
+++ b/demo_charts/values/oai-du.yq
@@ -17,6 +17,7 @@
 
 .start.tcpdump               = (strenv(PCAP) == "true") |
 .includeTcpDumpContainer     = (strenv(LOGS) == "true") |
+.includeMetricsParser        = (strenv(MONITORING) == "true") |
 .persistent.sharedvolume     = (strenv(PCAP) == "true") |
 
 .resources.define            = (strenv(QOS_DU) == "true") |

--- a/demo_charts/values/oai-gnb-fhi-72.yq
+++ b/demo_charts/values/oai-gnb-fhi-72.yq
@@ -13,5 +13,7 @@
 .config.ruCPlaneMacAdd       = strenv(MAC_RU) |
 .config.ruUPlaneMacAdd       = strenv(MAC_RU) |
 
+.includeMetricsParser        = (strenv(MONITORING) == "true") |
+
 .resources.define            = (strenv(QOS_GNB) == "true") |
 .nodeName                    = strenv(NODE_GNB)

--- a/demo_charts/values/oai-gnb.yq
+++ b/demo_charts/values/oai-gnb.yq
@@ -17,6 +17,7 @@
 
 .start.tcpdump               = (strenv(PCAP) == "true") |
 .includeTcpDumpContainer     = (strenv(LOGS) == "true") |
+.includeMetricsParser        = (strenv(MONITORING) == "true") |
 .persistent.sharedvolume     = (strenv(PCAP) == "true") |
 
 .resources.define            = (strenv(QOS_GNB) == "true") |

--- a/rru/oai-du-deployment-aw2s.yaml
+++ b/rru/oai-du-deployment-aw2s.yaml
@@ -214,6 +214,10 @@ spec:
             - name: usrp
               mountPath: /dev/bus/usb/
           {{- end }}
+          {{- if .Values.includeMetricsParser }}
+            - name: gnb-log-volume
+              mountPath: /shared-logs
+          {{- end}}
           env:
           - name: TZ
             value: {{ .Values.config.timeZone }}
@@ -282,6 +286,25 @@ spec:
           {{- end }}
         {{- end }}
 
+        {{- if .Values.includeMetricsParser }}
+        - name: metrics-parser
+          image: "{{ .Values.metricsParserImage.repository }}:{{ .Values.metricsParserImage.version }}"
+          imagePullPolicy: {{ .Values.metricsParserImage.pullPolicy }}
+          ports:
+            - containerPort: 9090
+              name: metrics
+          volumeMounts:
+          - name: gnb-log-volume
+            mountPath: /oai-gnb-logs
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+        {{- end }}
+
       volumes:
         - name: configuration
           configMap:
@@ -292,4 +315,8 @@ spec:
         - name: usrp
           hostPath:
             path: /dev/bus/usb/
+        {{- end }}
+        {{- if .Values.includeMetricsParser }} 
+        - name: gnb-log-volume
+          emptyDir: {}
         {{- end }}

--- a/rru/oai-gnb-deployment-aw2s.yaml
+++ b/rru/oai-gnb-deployment-aw2s.yaml
@@ -211,6 +211,10 @@ spec:
             - name: shared-data
               mountPath: /tmp
           {{- end }}
+          {{- if .Values.includeMetricsParser }}
+            - name: gnb-log-volume
+              mountPath: /shared-logs
+          {{- end}}
           env:
           - name: TZ
             value: {{ .Values.config.timeZone | quote }}
@@ -279,6 +283,25 @@ spec:
           {{- end }}
         {{- end }}
 
+        {{- if .Values.includeMetricsParser }}
+        - name: metrics-parser
+          image: "{{ .Values.metricsParserImage.repository }}:{{ .Values.metricsParserImage.version }}"
+          imagePullPolicy: {{ .Values.metricsParserImage.pullPolicy }}
+          ports:
+            - containerPort: 9090
+              name: metrics
+          volumeMounts:
+          - name: gnb-log-volume
+            mountPath: /oai-gnb-logs
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+        {{- end }}
+
       volumes:
         - name: configuration
           configMap:
@@ -294,4 +317,8 @@ spec:
         - name: shared-volume
           persistentVolumeClaim:
             claimName: shared-pvc
+        {{- end }}
+        {{- if .Values.includeMetricsParser }} 
+        - name: gnb-log-volume
+          emptyDir: {}
         {{- end }}


### PR DESCRIPTION
- Add metrics-parser container on gnb, du and cu/cu-cp deployment manifest files.
- Set `includeMetricsParser` chart value based on `MONITORING` boolean.
- Configure monitoring after starting the gnb in the `start-gnb` function on `demo-oai.sh`: run commands for copying the RAN logs to the shared folder between the gnb/cu-du and the corresponding metrics-parser.